### PR TITLE
Add support for upstream Storm on Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .coverage
 .DS_Store
 .eggs/
+.tox/
 Flask_Storm.egg-info/
 venv/
 doc/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
       env: STORM_PACKAGE=storm
     - python: 2.7
       env: STORM_PACKAGE=storm-legacy
-    - python: 3.3
-      env: STORM_PACKAGE=storm
-    - python: 3.3
-      env: STORM_PACKAGE=storm-legacy
     - python: 3.4
       env: STORM_PACKAGE=storm
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,25 @@ matrix:
     - python: 2.7
       env: STORM_PACKAGE=storm-legacy
     - python: 3.3
+      env: STORM_PACKAGE=storm
+    - python: 3.3
       env: STORM_PACKAGE=storm-legacy
+    - python: 3.4
+      env: STORM_PACKAGE=storm
     - python: 3.4
       env: STORM_PACKAGE=storm-legacy
     - python: 3.5
+      env: STORM_PACKAGE=storm
+    - python: 3.5
       env: STORM_PACKAGE=storm-legacy
     - python: 3.6
+      env: STORM_PACKAGE=storm
+    - python: 3.6
       env: STORM_PACKAGE=storm-legacy
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: STORM_PACKAGE=storm
     - python: 3.7
       dist: xenial
       sudo: true

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Flask-Storm
 ===========
 |test-status| |documentation-status| |pypi-version|
 
-*I only recommend using this package if your project is already heavily invested in Storm. Instead use* `SQLAlchemy <https://github.com/zzzeek/sqlalchemy>`_ *and* `Flask-SQLAlchemy <https://github.com/mitsuhiko/flask-sqlalchemy>`_. *It's uncertain if Storm will ever receive another update*
+*I only recommend using this package if your project is already heavily invested in Storm. Instead use* `SQLAlchemy <https://github.com/zzzeek/sqlalchemy>`_ *and* `Flask-SQLAlchemy <https://github.com/mitsuhiko/flask-sqlalchemy>`_.
 
 Flask-Storm is an extension for `Flask <https://www.palletsprojects.com/p/flask/>`_ that adds support for Canonical's ORM `Storm <https://storm.canonical.com/>`_ to your application. Flask-Storm automatically opens and closes database connections on demand when requests need them.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,14 @@ explicitly stated, changes are made by
 `Andreas Runfalk <https://github.com/runfalk>`_.
 
 
+Version 0.3.0
+-------------
+Released on <unreleased>
+
+- Dropped support for Python 3.3
+- Support Storm 0.21 which was recently released
+
+
 Version 0.2.0
 -------------
 Released on 8th October 2018

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,6 @@ if __name__ == "__main__":
             "Intended Audience :: Developers",
             "License :: OSI Approved :: MIT License",
             "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         license="MIT",
         author="Andreas Runfalk",
         author_email="andreas@runfalk.se",
-        url="https://www.github.com/runfalk/flask_storm",
+        url="https://www.github.com/runfalk/flask-storm",
         packages=["flask_storm"],
         platforms="any",
         install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py27-{storm,stormlegacy}
+    py33-stormlegacy
+    py34-stormlegacy
+    py35-stormlegacy
+    py36-stormlegacy
+    py37-stormlegacy
+
+[testenv]
+deps =
+    .[dev,fancy]
+    storm: storm
+    stormlegacy: storm-legacy
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27-{storm,stormlegacy}
-    py33-{storm,stormlegacy}
     py34-{storm,stormlegacy}
     py35-{storm,stormlegacy}
     py36-{storm,stormlegacy}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     py27-{storm,stormlegacy}
-    py33-stormlegacy
-    py34-stormlegacy
-    py35-stormlegacy
-    py36-stormlegacy
-    py37-stormlegacy
+    py33-{storm,stormlegacy}
+    py34-{storm,stormlegacy}
+    py35-{storm,stormlegacy}
+    py36-{storm,stormlegacy}
+    py37-{storm,stormlegacy}
 
 [testenv]
 deps =


### PR DESCRIPTION
Storm is maintained again (mostly by me at the moment) and supports Python 3, so test flask-storm with it.